### PR TITLE
BUG: self.population_view stopped working

### DIFF
--- a/src/vivarium_sodium_reduction/components/interventions.py
+++ b/src/vivarium_sodium_reduction/components/interventions.py
@@ -27,6 +27,10 @@ class RelativeShiftIntervention(Component):
     def configuration_defaults(self) -> Dict[str, Dict[str, Any]]:
         return {f"{self.name}": self.CONFIGURATION_DEFAULTS}
 
+    @property
+    def columns_required(self):
+        return ["age"]
+    
     def setup(self, builder: Builder) -> None:
         self.config = builder.configuration[self.name]
         self.shift_factor = self.config.shift_factor
@@ -34,14 +38,12 @@ class RelativeShiftIntervention(Component):
         self.age_start = self.config.age_start
         self.age_end = self.config.age_end
 
-        self.my_population_view = builder.population.get_view(["age"])
-
         builder.value.register_value_modifier(
             f"{self.target}.exposure", modifier=self.adjust_exposure, requires_columns=["age"]
         )
 
     def adjust_exposure(self, index: pd.Index, exposure: pd.Series) -> pd.Series:
-        pop = self.my_population_view.get(index)
+        pop = self.population_view.get(index)
         applicable_index = pop.loc[
             (self.age_start <= pop.age) & (pop.age < self.age_end)
         ].index

--- a/src/vivarium_sodium_reduction/components/interventions.py
+++ b/src/vivarium_sodium_reduction/components/interventions.py
@@ -30,7 +30,7 @@ class RelativeShiftIntervention(Component):
     @property
     def columns_required(self):
         return ["age"]
-    
+
     def setup(self, builder: Builder) -> None:
         self.config = builder.configuration[self.name]
         self.shift_factor = self.config.shift_factor

--- a/src/vivarium_sodium_reduction/components/interventions.py
+++ b/src/vivarium_sodium_reduction/components/interventions.py
@@ -34,14 +34,14 @@ class RelativeShiftIntervention(Component):
         self.age_start = self.config.age_start
         self.age_end = self.config.age_end
 
-        self.population_view = builder.population.get_view(["age"])
+        self.my_population_view = builder.population.get_view(["age"])
 
         builder.value.register_value_modifier(
             f"{self.target}.exposure", modifier=self.adjust_exposure, requires_columns=["age"]
         )
 
     def adjust_exposure(self, index: pd.Index, exposure: pd.Series) -> pd.Series:
-        pop = self.population_view.get(index)
+        pop = self.my_population_view.get(index)
         applicable_index = pop.loc[
             (self.age_start <= pop.age) & (pop.age < self.age_end)
         ].index


### PR DESCRIPTION
maybe there was a change in vivarium or vivarium_public_health that caused this

## Title: self.population_view stopped working, this change gets the sim to run again
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->bugfix

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This sim ran on 2024-09-26, but when I used `source environment.sh` yesterday, it upgraded some packages and no longer worked.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
after making this change, I was able to run with `simulate run -v --pdb src/vivarium_sodium_reduction/model_specifications/model_spec.yaml` successfully.

